### PR TITLE
PLT-8834 added new CRD to gateway yaml and values yaml to allow inter…

### DIFF
--- a/traefik/templates/gateway.yaml
+++ b/traefik/templates/gateway.yaml
@@ -3,7 +3,7 @@
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway
 metadata:
-  name: traefik-gateway
+  name: "{{ .Values.experimental.kubernetesGateway.className }}-gateway"
   namespace: {{ default (include "traefik.namespace" .) .Values.experimental.kubernetesGateway.namespace }}
   labels:
     {{- include "traefik.labels" . | nindent 4 }}
@@ -12,7 +12,7 @@ metadata:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  gatewayClassName: traefik
+  gatewayClassName: {{ .Values.experimental.kubernetesGateway.className }}
   listeners:
     - name: web
       port: {{ .Values.ports.web.port }}

--- a/traefik/templates/gatewayclass.yaml
+++ b/traefik/templates/gatewayclass.yaml
@@ -3,9 +3,9 @@
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: GatewayClass
 metadata:
-  name: traefik
+  name: {{ .Values.experimental.kubernetesGateway.className }}
   labels:
     {{- include "traefik.labels" . | nindent 4 }}
 spec:
-  controllerName: traefik.io/gateway-controller
+  controllerName: {{ .Values.experimental.kubernetesGateway.controllerName }}
 {{- end }}

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -125,7 +125,9 @@ experimental:
     enabled: false
   kubernetesGateway:
     # -- Enable traefik experimental GatewayClass CRD
-    enabled: false
+    enabled: true
+    className: traefik
+    controllerName: traefik.io/gateway-controller
     ## Routes are restricted to namespace of the gateway by default.
     ## https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.FromNamespaces
     # namespacePolicy: All
@@ -139,6 +141,7 @@ experimental:
     # Additional gateway annotations (e.g. for cert-manager.io/issuer)
     # annotations:
     #   cert-manager.io/issuer: letsencrypt
+
 
 ## Create an IngressRoute for the dashboard
 ingressRoute:


### PR DESCRIPTION
…nal traefik alongside existing traefik lb.

### What does this PR do?

Added new changes to the existing gateway yaml and gateway class to allow us to have an internal and external facing traefik lb.

<!-- A brief description of the change being made with this pull request. -->


### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

